### PR TITLE
Fix hyperlink for new site

### DIFF
--- a/e7-lab-team-optimizer/index.html
+++ b/e7-lab-team-optimizer/index.html
@@ -56,7 +56,7 @@
                 Epic Seven Labyrinth Team Optimizer v1.9 (Luluca)
             </h4>
             <h6 class='text-danger'>
-                This optimizer is now unsupported! Please visit <a href='www.epicseventools.com'>www.epicseventools.com</a> for the support version. Thanks!
+                This optimizer is now unsupported! Please visit <a href='http://www.epicseventools.com'>www.epicseventools.com</a> for the support version. Thanks!
             </h6>
             <a class='btn btn-sm btn-primary' href="http://www.epicseventools.com">Updated Version of the Lab Morale Optimizer</a>
             <br>


### PR DESCRIPTION
The link is currently broken (appearing as `https://budandan.github.io/e7-lab-team-optimizer/www.epicseventools.com`)

Small text change to fix